### PR TITLE
update: service agreement links and improve update check with fallback

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.yukisoffd.lyracode"
         minSdk = 26
         targetSdk = 36
-        versionCode = 68
-        versionName = "3.6.1"
+        versionCode = 69
+        versionName = "3.7.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField(

--- a/app/src/main/java/com/yukisoffd/lyracode/data/UpdateManager.kt
+++ b/app/src/main/java/com/yukisoffd/lyracode/data/UpdateManager.kt
@@ -24,7 +24,13 @@ data class AppUpdateInfo(
     val webUrl: String,
     val mandatory: Boolean,
 ) {
-    fun isNewerThan(currentVersionCode: Long): Boolean = versionCode > currentVersionCode
+    fun isNewerThan(currentVersionCode: Long, currentVersionName: String): Boolean {
+        return if (versionCode > 0L) {
+            versionCode > currentVersionCode
+        } else {
+            compareVersionNames(versionName, currentVersionName)?.let { it > 0 } == true
+        }
+    }
 }
 
 data class UpdateDownloadProgress(
@@ -48,28 +54,52 @@ class UpdateManager(private val context: Context) {
     fun manifestUrl(): String = com.yukisoffd.lyracode.BuildConfig.LYRA_UPDATE_MANIFEST_URL.trim()
 
     fun currentVersionCode(): Long {
-        val info = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            appContext.packageManager.getPackageInfo(appContext.packageName, android.content.pm.PackageManager.PackageInfoFlags.of(0))
-        } else {
-            @Suppress("DEPRECATION")
-            appContext.packageManager.getPackageInfo(appContext.packageName, 0)
-        }
+        val info = packageInfo()
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) info.longVersionCode else {
             @Suppress("DEPRECATION")
             info.versionCode.toLong()
         }
     }
 
-    fun checkForUpdate(): Result<AppUpdateInfo?> = runCatching {
-        val url = manifestUrl()
-        require(url.isNotBlank()) { "未配置更新清单地址，请在 gradle.properties 设置 lyra.updateManifestUrl" }
-        val request = Request.Builder().url(url).get().build()
-        client.newCall(request).execute().use { response ->
-            require(response.isSuccessful) { "版本检测失败：HTTP ${response.code}" }
-            val json = JSONObject(response.body?.string().orEmpty())
-            val info = parseUpdateInfo(json)
-            if (info.isNewerThan(currentVersionCode())) info else null
+    fun currentVersionName(): String = packageInfo().versionName.orEmpty()
+
+    private fun packageInfo(): android.content.pm.PackageInfo {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            appContext.packageManager.getPackageInfo(appContext.packageName, android.content.pm.PackageManager.PackageInfoFlags.of(0))
+        } else {
+            @Suppress("DEPRECATION")
+            appContext.packageManager.getPackageInfo(appContext.packageName, 0)
         }
+    }
+
+    fun checkForUpdate(): Result<AppUpdateInfo?> = runCatching {
+        val sources = buildList<Pair<String, () -> AppUpdateInfo>> {
+            manifestUrl().takeIf { it.isNotBlank() }?.let { url ->
+                add("网站 JSON" to { parseUpdateInfo(fetchJson(url)) })
+            }
+            add("GitHub" to {
+                parseReleaseUpdateInfo(
+                    json = fetchJson(GITHUB_LATEST_RELEASE_API),
+                    fallbackWebUrl = GITHUB_RELEASES_URL,
+                )
+            })
+            add("Gitee" to {
+                parseReleaseUpdateInfo(
+                    json = fetchJson(GITEE_LATEST_RELEASE_API),
+                    fallbackWebUrl = GITEE_RELEASES_URL,
+                )
+            })
+        }
+        val failures = mutableListOf<String>()
+        for ((name, load) in sources) {
+            try {
+                val info = load()
+                return@runCatching if (info.isNewerThan(currentVersionCode(), currentVersionName())) info else null
+            } catch (error: Exception) {
+                failures += "$name：${error.message.orEmpty().ifBlank { error.javaClass.simpleName }}"
+            }
+        }
+        error("版本检测失败，所有更新来源均不可用：${failures.joinToString("；")}")
     }
 
     fun checkDailyForUpdateIfNeeded(): Result<AppUpdateInfo?> = runCatching {
@@ -77,8 +107,8 @@ class UpdateManager(private val context: Context) {
         if (prefs.getString(KEY_LAST_DAILY_CHECK_DATE, "") == today) {
             return@runCatching latestAvailableUpdate()
         }
-        prefs.edit().putString(KEY_LAST_DAILY_CHECK_DATE, today).apply()
         val info = checkForUpdate().getOrThrow()
+        prefs.edit().putString(KEY_LAST_DAILY_CHECK_DATE, today).apply()
         if (info == null) {
             clearLatestAvailableUpdate()
         } else {
@@ -89,11 +119,7 @@ class UpdateManager(private val context: Context) {
 
     fun latestAvailableUpdate(): AppUpdateInfo? {
         val versionCode = prefs.getLong(KEY_LATEST_VERSION_CODE, 0L)
-        if (versionCode <= currentVersionCode()) {
-            clearLatestAvailableUpdate()
-            return null
-        }
-        return AppUpdateInfo(
+        val info = AppUpdateInfo(
             versionName = prefs.getString(KEY_LATEST_VERSION_NAME, "").orEmpty(),
             versionCode = versionCode,
             apkUrl = prefs.getString(KEY_LATEST_APK_URL, "").orEmpty(),
@@ -103,6 +129,11 @@ class UpdateManager(private val context: Context) {
             webUrl = prefs.getString(KEY_LATEST_WEB_URL, "").orEmpty(),
             mandatory = prefs.getBoolean(KEY_LATEST_MANDATORY, false),
         )
+        if (!info.isNewerThan(currentVersionCode(), currentVersionName())) {
+            clearLatestAvailableUpdate()
+            return null
+        }
+        return info
     }
 
     fun hasAvailableUpdate(): Boolean = latestAvailableUpdate() != null
@@ -228,7 +259,13 @@ class UpdateManager(private val context: Context) {
             return null
         }
         val pendingVersionCode = prefs.getLong(KEY_PENDING_VERSION_CODE, 0L)
-        if (pendingVersionCode > 0L && currentVersionCode() >= pendingVersionCode) {
+        val pendingVersionName = prefs.getString(KEY_PENDING_VERSION_NAME, "").orEmpty()
+        val installedTargetVersion = if (pendingVersionCode > 0L) {
+            currentVersionCode() >= pendingVersionCode
+        } else {
+            compareVersionNames(currentVersionName(), pendingVersionName)?.let { it >= 0 } == true
+        }
+        if (installedTargetVersion) {
             clearPendingApk()
             pruneCachedUpdateArtifacts()
             return null
@@ -301,6 +338,8 @@ class UpdateManager(private val context: Context) {
         val versionCode = json.optLong("versionCode").takeIf { it > 0 }
             ?: json.optLong("version_code").takeIf { it > 0 }
             ?: error("更新清单缺少 versionCode")
+        val apkUrl = json.optString("apkUrl").ifBlank { json.optString("apk_url") }
+        require(apkUrl.startsWith("https://") || apkUrl.startsWith("http://")) { "更新清单缺少有效的 apkUrl" }
         val releaseNotesUrl = json.optString("releaseNotesUrl").ifBlank { json.optString("release_notes_url") }
         val inlineNotes = json.optString("releaseNotes").ifBlank { json.optString("release_notes") }
         val releaseNotes = if (inlineNotes.isNotBlank() || releaseNotesUrl.isBlank()) {
@@ -316,13 +355,28 @@ class UpdateManager(private val context: Context) {
         return AppUpdateInfo(
             versionName = json.optString("versionName").ifBlank { json.optString("version_name") },
             versionCode = versionCode,
-            apkUrl = json.optString("apkUrl").ifBlank { json.optString("apk_url") },
+            apkUrl = apkUrl,
             apkSha256 = json.optString("apkSha256").ifBlank { json.optString("apk_sha256").ifBlank { json.optString("sha256") } },
             releaseNotes = releaseNotes.ifBlank { "发现新版本，暂无更新说明。" },
             releaseNotesUrl = releaseNotesUrl,
             webUrl = json.optString("webUrl").ifBlank { json.optString("web_url") },
             mandatory = json.optBoolean("mandatory", false),
         )
+    }
+
+    private fun fetchJson(url: String): JSONObject {
+        val request = Request.Builder()
+            .url(url)
+            .header("Accept", "application/json")
+            .header("User-Agent", "LyraCode/${currentVersionCode()} AndroidUpdateClient")
+            .get()
+            .build()
+        client.newCall(request).execute().use { response ->
+            require(response.isSuccessful) { "HTTP ${response.code}" }
+            val body = response.body?.string().orEmpty()
+            require(body.isNotBlank()) { "响应为空" }
+            return JSONObject(body)
+        }
     }
 
     private fun sha256(file: File): String {
@@ -399,7 +453,60 @@ class UpdateManager(private val context: Context) {
         const val KEY_LATEST_MANDATORY = "latest_mandatory"
         const val KEY_UPDATE_PROMPT_DISABLED = "update_prompt_disabled"
         const val KEY_LAST_UPDATE_PROMPT_DATE = "last_update_prompt_date"
+
+        const val GITHUB_LATEST_RELEASE_API = "https://api.github.com/repos/lyracode-app/Lyra-Code/releases/latest"
+        const val GITHUB_RELEASES_URL = "https://github.com/lyracode-app/Lyra-Code/releases"
+        const val GITEE_LATEST_RELEASE_API = "https://gitee.com/api/v5/repos/yukisoffd/lyra-code/releases/latest"
+        const val GITEE_RELEASES_URL = "https://gitee.com/yukisoffd/lyra-code/releases"
     }
+}
+
+internal fun parseReleaseUpdateInfo(json: JSONObject, fallbackWebUrl: String): AppUpdateInfo {
+    val tagName = json.optString("tag_name").trim()
+    require(versionComponents(tagName) != null) { "Release 缺少可识别的版本号" }
+    val assets = json.optJSONArray("assets") ?: error("Release 缺少安装包")
+    val apkUrl = (0 until assets.length())
+        .asSequence()
+        .mapNotNull { assets.optJSONObject(it) }
+        .firstOrNull { asset -> asset.optString("name").endsWith(".apk", ignoreCase = true) }
+        ?.optString("browser_download_url")
+        .orEmpty()
+    require(apkUrl.startsWith("https://") || apkUrl.startsWith("http://")) {
+        "Release 缺少 APK 的 browser_download_url"
+    }
+    val versionName = tagName.removePrefix("v").removePrefix("V")
+    val webUrl = json.optString("html_url").ifBlank { fallbackWebUrl }
+    return AppUpdateInfo(
+        versionName = versionName,
+        versionCode = 0L,
+        apkUrl = apkUrl,
+        apkSha256 = "",
+        releaseNotes = json.optString("body").ifBlank { "发现新版本，暂无更新说明。" },
+        releaseNotesUrl = webUrl,
+        webUrl = webUrl,
+        mandatory = false,
+    )
+}
+
+internal fun compareVersionNames(left: String, right: String): Int? {
+    val leftComponents = versionComponents(left) ?: return null
+    val rightComponents = versionComponents(right) ?: return null
+    val componentCount = maxOf(leftComponents.size, rightComponents.size)
+    for (index in 0 until componentCount) {
+        val comparison = (leftComponents.getOrNull(index) ?: 0L)
+            .compareTo(rightComponents.getOrNull(index) ?: 0L)
+        if (comparison != 0) return comparison
+    }
+    return 0
+}
+
+private fun versionComponents(value: String): List<Long>? {
+    val version = Regex("(?i)(?:^|[^0-9])v?(\\d+(?:\\.\\d+)*)(?:$|[^0-9])")
+        .find(value.trim())
+        ?.groupValues
+        ?.getOrNull(1)
+        ?: return null
+    return version.split('.').map { component -> component.toLongOrNull() ?: return null }
 }
 
 internal fun deleteCachedUpdateArtifacts(directory: File, keepFile: File? = null): Int {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1462,7 +1462,7 @@
     <string name="compliance_user_scope_title">1. Scope and parties</string>
     <string name="compliance_user_scope_body">Product: Lyra Code.
 Developer and maintainer: Soffd / Lyra Code project maintainers.
-Contact: https://github.com/Soffd/Lyra-Code/issues .
+Contact: https://github.com/lyracode-app/Lyra-Code/issues .
 
 This agreement covers the app and bundled local features. Providers of models, websites, MCP, and remote servers selected by you remain responsible for their services and may apply separate terms.</string>
     <string name="compliance_user_service_title">2. Services</string>
@@ -1518,7 +1518,7 @@ For access, correction, deletion, or complaints concerning information maintaine
     <string name="compliance_privacy_children_title">7. Children</string>
     <string name="compliance_privacy_children_body">The app is not specifically directed to children. Minors should use it with guardian guidance and should not submit identity, location, school, contact, or similar sensitive details to models, sites, or remote servers.</string>
     <string name="compliance_privacy_changes_title">8. Updates and contact</string>
-    <string name="compliance_privacy_changes_body">Material changes to features, permissions, third parties, or processing should be reflected in this policy and its date. Contact: https://github.com/Soffd/Lyra-Code/issues . Remove sensitive data before public feedback.</string>
+    <string name="compliance_privacy_changes_body">Material changes to features, permissions, third parties, or processing should be reflected in this policy and its date. Contact: https://github.com/lyracode-app/Lyra-Code/issues . Remove sensitive data before public feedback.</string>
 
     <string name="compliance_personal_summary">This list covers information the current version may process. “On demand” items are not read merely because the app is installed. External transmission depends on your actions, tool calls, and configuration.</string>
     <string name="compliance_personal_optional_profile_title">Nickname and avatar (optional)</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1545,7 +1545,7 @@
     <string name="compliance_user_scope_title">一、协议主体与适用范围</string>
     <string name="compliance_user_scope_body">产品名称：Lyra Code。
 开发者及项目维护者：Soffd / Lyra Code 项目维护者。
-联系渠道：https://github.com/Soffd/Lyra-Code/issues 。
+联系渠道：https://github.com/lyracode-app/Lyra-Code/issues 。
 
 本协议适用于应用本体及随版本提供的本地功能。用户自行接入的模型平台、网站、MCP 或远程服务器由相应服务方负责，并适用其另行公布的协议和政策。</string>
     <string name="compliance_user_service_title">二、服务内容</string>
@@ -1601,7 +1601,7 @@ API Key、密码、私钥和远程服务费用由用户自行管理。请勿分�
     <string name="compliance_privacy_children_title">七、未成年人</string>
     <string name="compliance_privacy_children_body">应用并非专门面向未成年人。未成年人应在监护人指导下使用，不应向模型、网站或远程服务器提交身份、位置、学校、联系方式等敏感信息。监护人可通过系统权限和清除应用数据进行管理。</string>
     <string name="compliance_privacy_changes_title">八、政策更新与联系</string>
-    <string name="compliance_privacy_changes_body">功能、权限、第三方服务或信息处理方式发生重要变化时，应更新本政策和清单并修改日期。联系渠道：https://github.com/Soffd/Lyra-Code/issues 。公开反馈时请先删除敏感信息。</string>
+    <string name="compliance_privacy_changes_body">功能、权限、第三方服务或信息处理方式发生重要变化时，应更新本政策和清单并修改日期。联系渠道：https://github.com/lyracode-app/Lyra-Code/issues 。公开反馈时请先删除敏感信息。</string>
 
     <string name="compliance_personal_summary">本清单按当前版本列出应用可能处理的信息。标注“按需”的项目不会因安装应用而自动读取；是否发送到外部取决于用户的操作、工具调用和服务配置。</string>
     <string name="compliance_personal_optional_profile_title">昵称与头像（可选）</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1545,7 +1545,7 @@
     <string name="compliance_user_scope_title">一、協議主體與適用範圍</string>
     <string name="compliance_user_scope_body">產品名稱：Lyra Code。
 開發者及專案維護者：Soffd / Lyra Code 專案維護者。
-聯絡渠道：https://github.com/Soffd/Lyra-Code/issues 。
+聯絡渠道：https://github.com/lyracode-app/Lyra-Code/issues 。
 
 本協議適用於應用本體及隨版本提供的本地功能。使用者自行接入的模型平臺、網站、MCP 或遠端伺服器由相應服務方負責，並適用其另行公佈的協議和政策。</string>
     <string name="compliance_user_service_title">二、服務內容</string>
@@ -1601,7 +1601,7 @@ API Key、密碼、私鑰和遠端服務費用由使用者自行管理。請勿�
     <string name="compliance_privacy_children_title">七、未成年人</string>
     <string name="compliance_privacy_children_body">應用並非專門面向未成年人。未成年人應在監護人指導下使用，不應向模型、網站或遠端伺服器提交身份、位置、學校、聯絡方式等敏感資訊。監護人可透過系統許可權和清除應用資料進行管理。</string>
     <string name="compliance_privacy_changes_title">八、政策更新與聯絡</string>
-    <string name="compliance_privacy_changes_body">功能、許可權、第三方服務或資訊處理方式發生重要變化時，應更新本政策和清單並修改日期。聯絡渠道：https://github.com/Soffd/Lyra-Code/issues 。公開反饋時請先刪除敏感資訊。</string>
+    <string name="compliance_privacy_changes_body">功能、許可權、第三方服務或資訊處理方式發生重要變化時，應更新本政策和清單並修改日期。聯絡渠道：https://github.com/lyracode-app/Lyra-Code/issues 。公開反饋時請先刪除敏感資訊。</string>
 
     <string name="compliance_personal_summary">本清單按當前版本列出應用可能處理的資訊。標註“按需”的專案不會因安裝應用而自動讀取；是否傳送到外部取決於使用者的操作、工具呼叫和服務配置。</string>
     <string name="compliance_personal_optional_profile_title">暱稱與頭像（可選）</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1462,7 +1462,7 @@
     <string name="compliance_user_scope_title">1. Scope and parties</string>
     <string name="compliance_user_scope_body">Product: Lyra Code.
 Developer and maintainer: Soffd / Lyra Code project maintainers.
-Contact: https://github.com/Soffd/Lyra-Code/issues .
+Contact: https://github.com/lyracode-app/Lyra-Code/issues .
 
 This agreement covers the app and bundled local features. Providers of models, websites, MCP, and remote servers selected by you remain responsible for their services and may apply separate terms.</string>
     <string name="compliance_user_service_title">2. Services</string>
@@ -1518,7 +1518,7 @@ For access, correction, deletion, or complaints concerning information maintaine
     <string name="compliance_privacy_children_title">7. Children</string>
     <string name="compliance_privacy_children_body">The app is not specifically directed to children. Minors should use it with guardian guidance and should not submit identity, location, school, contact, or similar sensitive details to models, sites, or remote servers.</string>
     <string name="compliance_privacy_changes_title">8. Updates and contact</string>
-    <string name="compliance_privacy_changes_body">Material changes to features, permissions, third parties, or processing should be reflected in this policy and its date. Contact: https://github.com/Soffd/Lyra-Code/issues . Remove sensitive data before public feedback.</string>
+    <string name="compliance_privacy_changes_body">Material changes to features, permissions, third parties, or processing should be reflected in this policy and its date. Contact: https://github.com/lyracode-app/Lyra-Code/issues . Remove sensitive data before public feedback.</string>
 
     <string name="compliance_personal_summary">This list covers information the current version may process. “On demand” items are not read merely because the app is installed. External transmission depends on your actions, tool calls, and configuration.</string>
     <string name="compliance_personal_optional_profile_title">Nickname and avatar (optional)</string>

--- a/app/src/test/java/com/yukisoffd/lyracode/data/UpdateManagerReleaseTest.kt
+++ b/app/src/test/java/com/yukisoffd/lyracode/data/UpdateManagerReleaseTest.kt
@@ -1,0 +1,68 @@
+package com.yukisoffd.lyracode.data
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UpdateManagerReleaseTest {
+    @Test
+    fun parsesGithubReleaseBodyAndApkDownloadUrl() {
+        val info = parseReleaseUpdateInfo(
+            JSONObject(
+                """
+                {
+                  "tag_name": "v3.7.0",
+                  "body": "Release details",
+                  "html_url": "https://github.com/lyracode-app/Lyra-Code/releases/tag/v3.7.0",
+                  "assets": [
+                    {
+                      "name": "lyracode-3.7.0.apk",
+                      "browser_download_url": "https://github.com/lyracode-app/Lyra-Code/releases/download/v3.7.0/lyracode-3.7.0.apk"
+                    }
+                  ]
+                }
+                """.trimIndent(),
+            ),
+            fallbackWebUrl = "https://github.com/lyracode-app/Lyra-Code/releases",
+        )
+
+        assertEquals("3.7.0", info.versionName)
+        assertEquals("Release details", info.releaseNotes)
+        assertEquals(
+            "https://github.com/lyracode-app/Lyra-Code/releases/download/v3.7.0/lyracode-3.7.0.apk",
+            info.apkUrl,
+        )
+        assertTrue(info.isNewerThan(currentVersionCode = 68L, currentVersionName = "3.6.1"))
+    }
+
+    @Test
+    fun selectsApkFromGiteeAssetsAndUsesFallbackReleasePage() {
+        val info = parseReleaseUpdateInfo(
+            JSONObject(
+                """
+                {
+                  "tag_name": "v3.10.0",
+                  "body": "Gitee details",
+                  "assets": [
+                    {
+                      "name": "v3.10.0.zip",
+                      "browser_download_url": "https://gitee.com/example/archive/v3.10.0.zip"
+                    },
+                    {
+                      "name": "lyracode-3.10.0.apk",
+                      "browser_download_url": "https://gitee.com/example/lyracode-3.10.0.apk"
+                    }
+                  ]
+                }
+                """.trimIndent(),
+            ),
+            fallbackWebUrl = "https://gitee.com/yukisoffd/lyra-code/releases",
+        )
+
+        assertEquals("https://gitee.com/example/lyracode-3.10.0.apk", info.apkUrl)
+        assertEquals("https://gitee.com/yukisoffd/lyra-code/releases", info.webUrl)
+        assertEquals(1, compareVersionNames("3.10.0", "3.9.9"))
+        assertEquals(0, compareVersionNames("v3.10", "3.10.0-debug"))
+    }
+}


### PR DESCRIPTION
- Update outdated GitHub links in the service agreement to valid addresses
- Add GitHub and Gitee fallback checks for update detection, automatically switching to the backup source when the primary source is unavailable, improving update retrieval reliability

## 变更说明

<!-- 简要说明此 PR 解决的问题、实现方式和主要改动。 -->

## 关联 Issue

<!-- 使用 Closes #123、Fixes #123 或 Related to #123。没有关联 Issue 时请说明原因。 -->

## 变更类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构或性能优化
- [x] 文档或构建配置
- [ ] 其他

## 验证方式

<!-- 列出执行过的测试、命令和手动验证步骤，并写明结果。 -->

## 界面变化

<!-- 涉及界面时请提供变更前后截图或录屏；不涉及请填写“不适用”。 -->

## 提交前检查

- [ ] 本 PR 只包含一个明确主题，没有混入无关修改。
- [ ] 没有遗留调试代码或敏感信息。
- [ ] 我已在受影响的 Android 版本或设备上完成必要验证。
- [ ] 我已为新增或变更的行为补充测试；若无法补充，已在上方说明原因。
- [ ] 面向用户的行为或配置发生变化时，我已同步更新相关文档。
- [ ] 所有提交信息清晰、可追溯；需要时已整理提交历史。

## 补充说明

<!-- 可填写兼容性影响、已知限制、后续工作或审阅时需特别关注的内容。 -->
